### PR TITLE
fix: 채팅방 조회 시 상대방 이름으로 방 이름 설정

### DIFF
--- a/karma/src/main/java/com/ecyce/karma/domain/chat/controller/ChatMessageController.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/chat/controller/ChatMessageController.java
@@ -1,9 +1,11 @@
 package com.ecyce.karma.domain.chat.controller;
 
+import com.ecyce.karma.domain.auth.customAnnotation.AuthUser;
 import com.ecyce.karma.domain.chat.dto.ChatListResponseDto;
 import com.ecyce.karma.domain.chat.dto.ChatMessageDto;
 import com.ecyce.karma.domain.chat.entity.ChatMessage;
 import com.ecyce.karma.domain.chat.service.ChatMessageService;
+import com.ecyce.karma.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -27,8 +29,8 @@ public class ChatMessageController {
 
     /* 채팅방의 채팅 내역 조회 */
     @GetMapping("/chat/messages/{roomId}")
-    public ResponseEntity<ChatListResponseDto> getMessagesByRoomId(@PathVariable("roomId") Long roomId) {
-        ChatListResponseDto response = chatMessageService.findMessagesByRoomId(roomId);
+    public ResponseEntity<ChatListResponseDto> getMessagesByRoomId(@PathVariable("roomId") Long roomId, @AuthUser User user) {
+        ChatListResponseDto response = chatMessageService.findMessagesByRoomId(roomId, user);
         return ResponseEntity.ok(response);
     }
 }

--- a/karma/src/main/java/com/ecyce/karma/domain/chat/dto/ChatRoomListDto.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/chat/dto/ChatRoomListDto.java
@@ -2,6 +2,7 @@ package com.ecyce.karma.domain.chat.dto;
 
 import com.ecyce.karma.domain.chat.entity.ChatMessage;
 import com.ecyce.karma.domain.chat.entity.ChatRoom;
+import com.ecyce.karma.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,8 +13,18 @@ public class ChatRoomListDto {
     private String roomName;
     private String latestMessage;
 
-    public static ChatRoomListDto from(ChatRoom chatRoom, ChatMessage latestMessage) {
-        String content = (latestMessage != null) ? latestMessage.getContent() : "채팅 내역이 존재하지 않습니다. 채팅을 시작해보세요!";
-        return new ChatRoomListDto(chatRoom.getRoomId(), chatRoom.getName(), content);
+    public static ChatRoomListDto from(ChatRoom chatRoom, ChatMessage latestMessage, User currentUser) {
+        // 상대방 이름으로 방 이름 설정
+        String otherUserName = chatRoom.getBuyer().equals(currentUser)
+                ? chatRoom.getSeller().getNickname()
+                : chatRoom.getBuyer().getNickname();
+
+        String content = (latestMessage != null) ? latestMessage.getContent() : "채팅 내역이 없습니다.";
+
+        return new ChatRoomListDto(
+                chatRoom.getRoomId(),
+                otherUserName,
+                content
+        );
     }
 }

--- a/karma/src/main/java/com/ecyce/karma/domain/chat/service/ChatMessageService.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/chat/service/ChatMessageService.java
@@ -34,14 +34,18 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public ChatListResponseDto findMessagesByRoomId(Long roomId) {
+    public ChatListResponseDto findMessagesByRoomId(Long roomId, User currentUser) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("INVALID_ROOM_ID"));
 
-        List<ChatMessageDto> messageDtos = chatMessageRepository.findByChatRoomRoomId(roomId).stream()
+        // 상대방 이름으로 방 이름 설정
+        String roomName = chatRoom.getBuyer().equals(currentUser) ? chatRoom.getSeller().getNickname() : chatRoom.getBuyer().getNickname();
+
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoomOrderByTimestampAsc(chatRoom);
+        List<ChatMessageDto> messageDtos = messages.stream()
                 .map(ChatMessageDto::from)
                 .collect(Collectors.toList());
 
-        return ChatListResponseDto.of(chatRoom.getRoomId(), chatRoom.getName(), messageDtos);
+        return ChatListResponseDto.of(chatRoom.getRoomId(), roomName, messageDtos);
     }
 }

--- a/karma/src/main/java/com/ecyce/karma/domain/chat/service/ChatRoomService.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/chat/service/ChatRoomService.java
@@ -53,25 +53,19 @@ public class ChatRoomService {
     /* 전체 채팅방 목록: 사용자가 buyer 또는 seller로 참여한 채팅방 */
     public List<ChatRoomListDto> findAllChatRooms(User user) {
         List<ChatRoom> chatRooms = chatRoomRepository.findByBuyerOrSeller(user, user);
-        return chatRooms.stream()
-                .map(this::toChatRoomListDto)
-                .collect(Collectors.toList());
+        return mapToChatRoomListDto(chatRooms, user);
     }
 
     /* 판매 채팅방 목록: 사용자가 seller로 참여한 채팅방 */
     public List<ChatRoomListDto> findSellingChatRooms(User user) {
         List<ChatRoom> chatRooms = chatRoomRepository.findBySeller(user); // 판매자 기준
-        return chatRooms.stream()
-                .map(this::toChatRoomListDto)
-                .collect(Collectors.toList());
+        return mapToChatRoomListDto(chatRooms, user);
     }
 
     /* 구매 채팅방 목록: 사용자가 buyer로 참여한 채팅방 */
     public List<ChatRoomListDto> findBuyingChatRooms(User user) {
         List<ChatRoom> chatRooms = chatRoomRepository.findByBuyer(user); // 구매자 기준
-        return chatRooms.stream()
-                .map(this::toChatRoomListDto)
-                .collect(Collectors.toList());
+        return mapToChatRoomListDto(chatRooms, user);
     }
 
     /* 특정 채팅방의 상세 정보 조회 */
@@ -84,9 +78,13 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
-    // ChatRoom을 ChatRoomListDto로 변환
-    private ChatRoomListDto toChatRoomListDto(ChatRoom chatRoom) {
-        ChatMessage latestMessage = chatMessageRepository.findTopByChatRoomOrderByTimestampDesc(chatRoom);
-        return ChatRoomListDto.from(chatRoom, latestMessage);
+    /* ChatRoom을 ChatRoomListDto로 변환 */
+    private List<ChatRoomListDto> mapToChatRoomListDto(List<ChatRoom> chatRooms, User currentUser) {
+        return chatRooms.stream()
+                .map(chatRoom -> {
+                    ChatMessage latestMessage = chatMessageRepository.findTopByChatRoomOrderByTimestampDesc(chatRoom);
+                    return ChatRoomListDto.from(chatRoom, latestMessage, currentUser);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/karma/src/main/java/com/ecyce/karma/global/config/WebSocketConfig.java
+++ b/karma/src/main/java/com/ecyce/karma/global/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws") // /ws으로 들어오는 경우
-                .setAllowedOrigins("https://jiangxy.github.io", "http://localhost:3000", "https://api.ecyce-karma.n-e.kr")
+                .setAllowedOrigins("https://jiangxy.github.io", "http://localhost:3000", "https://api.ecyce-karma.n-e.kr", "ws://localhost:8080", "wss://api.ecyce-karma.n-e.kr")
                 .withSockJS();
     }
 


### PR DESCRIPTION
## 변경 사항
- #14 
- 채팅방 목록 조회 시 roomName을 채팅 상대방 이름으로 설정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
ex) feat/chat -> main

### 기타