### PR TITLE
feat : order에서 송장번호와 택배사 분리 & 판매자 id반환

### DIFF
--- a/karma/src/main/java/com/ecyce/karma/domain/order/controller/OrdersController.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/order/controller/OrdersController.java
@@ -83,10 +83,11 @@ public class OrdersController {
     @PatchMapping("/{orderId}/ship")
     public ResponseEntity<String> startShipping(
             @PathVariable Long orderId,
+            @RequestParam String deliveryCompany,
             @RequestParam String invoiceNumber,
             @AuthUser User seller
     ) {
-        ordersService.startShipping(orderId, seller, invoiceNumber);
+        ordersService.startShipping(orderId, seller, deliveryCompany,invoiceNumber);
         return ResponseEntity.ok("배송이 시작되었습니다.");
     }
 

--- a/karma/src/main/java/com/ecyce/karma/domain/order/dto/OrderResponseDto.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/order/dto/OrderResponseDto.java
@@ -25,18 +25,21 @@ public class OrderResponseDto {
     private String buyerNotice;
 
     // 판매자 정보
+    private Long sellerId;
     private String sellerNickname;
     private String sellerName;
     private String sellerPhone;
     private String sellerAddress;
 
     // 구매자 정보
+    private Long buyerId;
     private String buyerNickname;
     private String buyerName;
     private String buyerPhone;
     private String buyerAddress;
 
     // 배송 정보
+    private String deliveryCompany;
     private String invoiceNumber;
 
     // 결제 정보
@@ -58,17 +61,20 @@ public class OrderResponseDto {
                 order.getProduct().getMaterialInfo(),
                 order.getProduct().getBuyerNotice(),
                 // 판매자 정보
+                order.getSellerUser().getUserId(),
                 order.getSellerUser().getNickname(),
                 order.getSellerUser().getName(),
                 order.getSellerUser().getPhoneNumber(),
                 order.getSellerUser().getAddress().toString(),
                 // 구매자 정보
+                order.getBuyerUser().getUserId(),
                 order.getBuyerUser().getNickname(),
                 order.getBuyerUser().getName(),
                 order.getBuyerUser().getPhoneNumber(),
                 order.getBuyerUser().getAddress().toString(),
                 // 배송 정보
-                order.getInvoiceNumber() != null ? order.getInvoiceNumber() : "미발행",
+                order.getDeliveryCompany() != null ? order.getDeliveryCompany() : "택배사 미발행",
+                order.getInvoiceNumber() != null ? order.getInvoiceNumber() : "송장번호 미발행",
                 // 결제 정보
                 (order.getProduct()
                      .getPrice()+order.getProductOption().getOptionPrice())* order.getOrderCount(),

--- a/karma/src/main/java/com/ecyce/karma/domain/order/entity/Orders.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/order/entity/Orders.java
@@ -39,6 +39,9 @@ public class Orders extends BaseTimeEntity {
     private Integer orderCount;
 
     @Column
+    private String deliveryCompany; // 택배회사
+
+    @Column
     private String invoiceNumber; // 송장번호
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -110,13 +113,14 @@ public class Orders extends BaseTimeEntity {
     }
 
     // 4. 배송 시작 (송장번호 추가)
-    public void startShipping(String invoiceNumber) {
+    public void startShipping(String deliveryCompany, String invoiceNumber) {
         if (orderState != OrderState.제작완료) {
             throw new CustomException(ErrorCode.INVALID_ORDER_STATE, String.format("현재 상태는 '%s'이며, 제작 완료 상태에서만 배송을 시작할 수 있습니다.", orderState));
         }
         if (invoiceNumber == null || invoiceNumber.isBlank()) {
             throw new CustomException(ErrorCode.INVOICE_NUMBER_REQUIRED);
         }
+        this.deliveryCompany = deliveryCompany;
         this.invoiceNumber = invoiceNumber;
         this.orderState = OrderState.배송중;
     }

--- a/karma/src/main/java/com/ecyce/karma/domain/order/service/OrdersService.java
+++ b/karma/src/main/java/com/ecyce/karma/domain/order/service/OrdersService.java
@@ -114,13 +114,13 @@ public class OrdersService {
     }
 
     // 배송 시작
-    public void startShipping(Long orderId, User seller, String invoiceNumber) {
+    public void startShipping(Long orderId, User seller, String deliveryCompany,String invoiceNumber) {
         Orders order = orderRepository.findByOrderId(orderId)
                                        .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
         if (!order.getSellerUser().equals(seller)) {
             throw new CustomException(ErrorCode.ORDER_ACCESS_DENIED);
         }
-        order.startShipping(invoiceNumber);
+        order.startShipping(deliveryCompany,invoiceNumber);
     }
 
     // 구매 확정


### PR DESCRIPTION
## 변경 사항
- 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제

### 기타
Order Entity -> 송장번호만 invoiceNumber로 전부 받았는데, deliveryCompany, invoiceNumber로 택배사와 송장번호 분리
(ex. 한진택배 12341234)
<img width="742" alt="image" src="https://github.com/user-attachments/assets/8824fb52-d597-444f-a5b1-51fc64ceb3f3">

주문 상세조회 시 유저 아이디도 함께 반환
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/bf0f2ff2-61a7-48fa-aa60-87dd5576243c">

